### PR TITLE
v1.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+v1.2.0
+
+- cleaned `lazy_static` re-export, now only re-exporting `lazy_static` macro
+- added a `capacity` method on the consign
+- added `collect`, `shrink_to_fit`, `collect_to_fit` and `reserve` to the `HashConsign` trait
+
 v1.1.0
 
 - removed systematic unsafe implementations of `Send` and `Sync` for `HConsed`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashconsing"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Adrien Champion <adrien.champion@email.com>"]
 description = "A hash consing library."
 documentation = "https://docs.rs/hashconsing"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 
 //! Hash consing library.
 //!
-//! This library is based on [Type-Safe Modular Hash-Consing](paper) by Filiâtre and Conchon. It is
+//! This library is based on [Type-Safe Modular Hash-Consing][paper] by Filiâtre and Conchon. It is
 //! probably less efficient as uses Rust's `HashMap`s, not a custom built structure.
 //!
 //! If you are not familiar with hashconsing, see the [example](#example) below or read the paper.
@@ -222,7 +222,7 @@ use std::{
     sync::{Arc, RwLock, Weak},
 };
 
-pub use lazy_static::*;
+pub use lazy_static::lazy_static;
 
 /// Creates a lazy static consign.
 ///

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,4 @@
+//! Testing.
+
+mod basic;
+mod collect;

--- a/src/test/basic.rs
+++ b/src/test/basic.rs
@@ -1,0 +1,114 @@
+//! Some basic tests.
+
+use std::fmt;
+
+use crate::*;
+
+type Term = HConsed<ActualTerm>;
+
+#[derive(Hash, Clone, PartialEq, Eq)]
+enum ActualTerm {
+    Var(usize),
+    Lam(Term),
+    App(Term, Term),
+}
+
+impl fmt::Display for ActualTerm {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &Self::Var(i) => write!(fmt, "v{}", i),
+            &Self::Lam(ref t) => write!(fmt, "({})", t.get()),
+            &Self::App(ref u, ref v) => write!(fmt, "{}.{}", u.get(), v.get()),
+        }
+    }
+}
+
+trait TermFactory {
+    fn var(&mut self, v: usize) -> Term;
+    fn lam(&mut self, t: Term) -> Term;
+    fn app(&mut self, u: Term, v: Term) -> Term;
+}
+
+impl TermFactory for HConsign<ActualTerm> {
+    fn var(&mut self, v: usize) -> Term {
+        self.mk(ActualTerm::Var(v))
+    }
+    fn lam(&mut self, t: Term) -> Term {
+        self.mk(ActualTerm::Lam(t))
+    }
+    fn app(&mut self, u: Term, v: Term) -> Term {
+        self.mk(ActualTerm::App(u, v))
+    }
+}
+
+#[test]
+fn run() {
+    use coll::{HConMap, HConSet};
+
+    let mut consign = HConsign::empty();
+    assert_eq!(consign.len(), 0);
+
+    let mut map: HConMap<Term, _> = HConMap::with_capacity(100);
+    let mut set: HConSet<Term> = HConSet::with_capacity(100);
+
+    let (v1, v1_name) = (consign.var(0), "v1");
+    println!("creating {}", v1);
+    assert_eq!(consign.len(), 1);
+    let prev = map.insert(v1.clone(), v1_name);
+    assert_eq!(prev, None);
+    let is_new = set.insert(v1.clone());
+    assert!(is_new);
+
+    let (v2, v2_name) = (consign.var(3), "v2");
+    println!("creating {}", v2);
+    assert_eq!(consign.len(), 2);
+    assert_ne!(v1.uid(), v2.uid());
+    let prev = map.insert(v2.clone(), v2_name);
+    assert_eq!(prev, None);
+    let is_new = set.insert(v2.clone());
+    assert!(is_new);
+
+    let (lam, lam_name) = (consign.lam(v2.clone()), "lam");
+    println!("creating {}", lam);
+    assert_eq!(consign.len(), 3);
+    assert_ne!(v1.uid(), lam.uid());
+    assert_ne!(v2.uid(), lam.uid());
+    let prev = map.insert(lam.clone(), lam_name);
+    assert_eq!(prev, None);
+    let is_new = set.insert(lam.clone());
+    assert!(is_new);
+
+    let (v3, v3_name) = (consign.var(3), "v3");
+    println!("creating {}", v3);
+    assert_eq!(consign.len(), 3);
+    assert_eq!(v2.uid(), v3.uid());
+    let prev = map.insert(v3.clone(), v3_name);
+    assert_eq!(prev, Some(v2_name));
+    let is_new = set.insert(v3.clone());
+    assert!(!is_new);
+
+    let (lam2, lam2_name) = (consign.lam(v3.clone()), "lam2");
+    println!("creating {}", lam2);
+    assert_eq!(consign.len(), 3);
+    assert_eq!(lam.uid(), lam2.uid());
+    let prev = map.insert(lam2.clone(), lam2_name);
+    assert_eq!(prev, Some(lam_name));
+    let is_new = set.insert(lam2.clone());
+    assert!(!is_new);
+
+    let (app, app_name) = (consign.app(lam2, v1), "app");
+    println!("creating {}", app);
+    assert_eq!(consign.len(), 4);
+    let prev = map.insert(app.clone(), app_name);
+    assert_eq!(prev, None);
+    let is_new = set.insert(app.clone());
+    assert!(is_new);
+
+    for term in &set {
+        assert!(map.contains_key(term))
+    }
+    for (term, val) in &map {
+        println!("looking for `{}`", val);
+        assert!(set.contains(term))
+    }
+}

--- a/src/test/collect.rs
+++ b/src/test/collect.rs
@@ -1,0 +1,109 @@
+//! Tests for the `collect` feature of the `HConsign`.
+
+pub mod term {
+    use crate::*;
+
+    pub type Term = HConsed<RawTerm>;
+
+    consign! {
+        /// Factory for terms.
+        let FACTORY = consign(37) for RawTerm ;
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+    pub enum RawTerm {
+        Cst(usize),
+        Var(String),
+        App { op: String, args: Vec<Term> },
+    }
+
+    pub fn cst(cst: usize) -> Term {
+        FACTORY.mk(RawTerm::Cst(cst))
+    }
+    pub fn var(var: impl Into<String>) -> Term {
+        FACTORY.mk(RawTerm::Var(var.into()))
+    }
+    pub fn app(op: impl Into<String>, args: Vec<Term>) -> Term {
+        FACTORY.mk(RawTerm::App {
+            op: op.into(),
+            args,
+        })
+    }
+
+    pub fn collect() {
+        FACTORY.collect()
+    }
+
+    pub fn factory_do<T>(f: impl FnOnce(&mut HConsign<RawTerm>) -> T) -> T {
+        f(&mut FACTORY.write().expect("factory is poisoned T_T"))
+    }
+}
+
+use term::Term;
+
+// (Sub)terms created by `create_1` and `create_2` do not overlap
+pub fn create_1() -> Term {
+    let var = term::var("v_2");
+    let cst = term::cst(8);
+    let app_1 = term::app("+", vec![var, cst]);
+    let app_2 = term::app("-", vec![app_1]);
+    app_2
+}
+pub fn create_2() -> Term {
+    let var = term::var("v_1");
+    let cst = term::cst(7);
+    let app_1 = term::app("+", vec![var, cst]);
+    let app_2 = term::app("-", vec![app_1]);
+    app_2
+}
+
+pub fn factory_len() -> usize {
+    term::factory_do(|f| f.len())
+}
+
+#[test]
+pub fn collect() {
+    println!("Factory is empty.");
+    assert_eq!(factory_len(), 0);
+
+    {
+        let term = create_1();
+        println!("Should have 4 terms in the factory right now.");
+        assert_eq!(factory_len(), 4);
+        assert_eq!(term.uid(), 3);
+        println!("Collect should not do anything.");
+        term::collect();
+        assert_eq!(factory_len(), 4);
+    };
+
+    println!("Should still have 4 (weak) terms in the factory.");
+    assert_eq!(factory_len(), 4);
+    println!("Collect should drop everything in the table.");
+    term::collect();
+    assert_eq!(factory_len(), 0);
+
+    {
+        println!("Next uid should be `0`.");
+        let leaf_t = term::var("v");
+        assert_eq!(leaf_t.uid(), 0);
+    }
+    term::collect();
+    assert_eq!(factory_len(), 0);
+
+    let t = {
+        println!("Putting 4 terms we're going to drop in the consign.");
+        let _dont_care = create_1();
+        println!("And then 4 other terms we keep.");
+        create_2()
+    };
+    assert_eq!(factory_len(), 8);
+    println!("Collect should drop the first 4 terms.");
+    term::collect();
+    assert_eq!(factory_len(), 4);
+
+    println!("Now, the table's internal UID counter should not have changed.");
+    assert_eq!(t.uid(), 7);
+    println!("Next uid should be `8`.");
+    let leaf_t = term::var("v");
+    assert_eq!(leaf_t.uid(), 8);
+}


### PR DESCRIPTION
- minor doc fixes
- added `collect` to the `HashConsign` trait
    - removes entries of the consign that have a strong count of `0` (recursively)
    - lowers the internal UID counter to the lowest possible value
- lifted a few methods from `HashMap` to `HashConsign`
- added tests for `collect` and moved existing tests around