### PR TITLE
Publicize weak variant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ impl<T: fmt::Display> fmt::Display for HConsed<T> {
 }
 
 /// Weak version of `HConsed` (internal).
-struct WHConsed<T> {
+pub struct WHConsed<T> {
     /// The actual element.
     elm: Weak<T>,
     /// Unique identifier of the element.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ impl<T> HConsed<T> {
     }
     /// Turns a hashconsed thing in a weak hashconsed thing.
     #[inline]
-    fn to_weak(&self) -> WHConsed<T> {
+    pub fn to_weak(&self) -> WHConsed<T> {
         WHConsed {
             elm: Arc::downgrade(&self.elm),
             uid: self.uid,


### PR DESCRIPTION
Hi Adrian,

First off, thank you for making this great library! It's been a pleasure to use so far!

## What this PR does

This PR publicize the weak-reference variants of hash-consed data.

## Why (I claim) that is a good idea

This allows users of the library to hold references to terms which do not prevent garbage collection of the term itself, which can be useful (see below!).

## My case-study of using this PR

In a small project I'm currently working on, I'm using this library to help with efficiently manipulating SMT-like terms. In this project, I've found it useful to maintain a global map from terms to their types (something like their "sorts"), which is lazily updated as terms are type-checked. This kind of global table greatly accelerates type-checking, which is very nice! However, this table should not prevent garbage collection. Thus, it needs weak pointers.

## Prior art/related work

In general, what I describe about is one example of the [attribute system used in CVC4](https://github.com/CVC4/CVC4/blob/master/src/expr/attribute.h#L40), which have been a *very* useful tool in that project, and I'm finding are pretty useful in mine as well.

CVC4 also uses these weak reference pervasively, which I'm not as convinced is a good idea, but attributes are quite useful for lazy, global analyses.

Anyways, let me know what you think. No hard feelings if you don't want to merge---I can always just stay on my fork.

Cheers,
Alex